### PR TITLE
Added direct encoding/decoding functions

### DIFF
--- a/src/charset/gb2312.rs
+++ b/src/charset/gb2312.rs
@@ -19,7 +19,7 @@ pub fn encode(src: &str, dst: &mut Vec<u8>) {
             let hi = usize::from(c >> 8);
             let lo = usize::from(c & 0xFF);
 
-            let pos = HI_MAP[hi] * 0xFF + usize::from(lo);
+            let pos = HI_MAP[hi] * 0xFF + lo;
             let code = ENCODE_MAP[pos];
             if code != 0x0000 {
                 dst.push((code >> 8) as u8);
@@ -68,6 +68,20 @@ pub fn decode(src: &[u8], dst: &mut String) {
             dst.push(unsafe { std::char::from_u32_unchecked(c) })
         }
     }
+}
+
+
+pub fn encode_to_vec(src: &str) -> Vec<u8> {
+    let mut ret = Vec::new();
+    encode(src, &mut ret);
+    ret
+}
+
+
+pub fn decode_to_string(src: &[u8]) -> String {
+    let mut ret = String::new();
+    decode(src, &mut ret);
+    ret
 }
 
 

--- a/src/charset/iso6937.rs
+++ b/src/charset/iso6937.rs
@@ -17,7 +17,7 @@ pub (crate) fn singlechar_encode(src: &str, dst: &mut Vec<u8>, hi_map: &[usize],
             let hi = usize::from(c >> 8);
             let lo = usize::from(c & 0xFF);
 
-            let pos = hi_map[hi] * 0xFF + usize::from(lo);
+            let pos = hi_map[hi] * 0xFF + lo;
             let code = map[pos];
 
             if code != 0x0000 {
@@ -70,6 +70,22 @@ pub fn encode(src: &str, dst: &mut Vec<u8>) {
 #[inline]
 pub fn decode(src: &[u8], dst: &mut String) {
     singlechar_decode(src, dst, &DECODE_MAP)
+}
+
+
+#[inline]
+pub fn encode_to_vec(src: &str) -> Vec<u8> {
+    let mut ret = Vec::new();
+    singlechar_encode(src, &mut ret, &HI_MAP, &ENCODE_MAP);
+    ret
+}
+
+
+#[inline]
+pub fn decode_to_string(src: &[u8]) -> String {
+    let mut ret = String::new();
+    singlechar_decode(src, &mut ret, &DECODE_MAP);
+    ret
 }
 
 

--- a/src/charset/iso8859.rs
+++ b/src/charset/iso8859.rs
@@ -25,6 +25,20 @@ macro_rules! iso8859 {
                 }
 
                 #[inline]
+                pub fn encode_to_vec(src: &str) -> Vec<u8> {
+                    let mut ret = Vec::new();
+                    singlechar_encode(src, &mut ret, &$hi_map, &$encode_map);
+                    ret
+                }
+
+                #[inline]
+                pub fn decode_to_string(src: &[u8]) -> String {
+                    let mut ret = String::new();
+                    singlechar_decode(src, &mut ret, &$decode_map);
+                    ret
+                }
+
+                #[inline]
                 pub fn bound(src: &[u8], limit: usize) -> usize {
                     std::cmp::min(src.len(), limit)
                 }

--- a/src/charset/utf8.rs
+++ b/src/charset/utf8.rs
@@ -16,6 +16,21 @@ pub fn decode(src: &[u8], dst: &mut String) {
 }
 
 
+#[inline]
+pub fn encode_to_vec(src: &str) -> Vec<u8> {
+    let mut ret = Vec::new();
+    encode(src, &mut ret);
+    ret
+}
+
+
+#[inline]
+pub fn decode_to_string(src: &[u8]) -> String {
+    let mut ret = String::new();
+    decode(src, &mut ret);
+    ret
+}
+
 pub fn bound(src: &[u8], limit: usize) -> usize {
     if limit == 0 {
         return limit;

--- a/tests/gb2312.rs
+++ b/tests/gb2312.rs
@@ -16,9 +16,15 @@ fn test_gb2312() {
     gb2312::encode(u, &mut dst);
     assert_eq!(dst.as_slice(), c);
 
+    let enc = gb2312::encode_to_vec(u);
+    assert_eq!(dst, enc);
+
     let mut dst = String::new();
     gb2312::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+    
+    let dec = gb2312::decode_to_string(c);
+    assert_eq!(dst, dec);
 
     let bound = gb2312::bound(c, 10000);
     assert_eq!(bound, c.len());

--- a/tests/iso6937.rs
+++ b/tests/iso6937.rs
@@ -20,7 +20,13 @@ fn test_iso6937() {
     iso6937::encode(u, &mut dst);
     assert_eq!(dst.as_slice(), c);
 
+    let enc = iso6937::encode_to_vec(u);
+    assert_eq!(enc, dst);
+
     let mut dst = String::new();
     iso6937::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = iso6937::decode_to_string(c);
+    assert_eq!(dst, dec);
 }

--- a/tests/iso8859.rs
+++ b/tests/iso8859.rs
@@ -10,9 +10,15 @@ fn test_iso8859_5() {
     iso8859_5::encode(u, &mut dst);
     assert_eq!(dst.as_slice(), c);
 
+    let enc = iso8859_5::encode_to_vec(u);
+    assert_eq!(enc, dst);
+
     let mut dst = String::new();
     iso8859_5::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = iso8859_5::decode_to_string(c);
+    assert_eq!(dec, dst);
 }
 
 
@@ -28,9 +34,15 @@ fn test_iso8859_6() {
     iso8859_6::encode(u, &mut dst);
     assert_eq!(dst.as_slice(), c);
 
+    let enc = iso8859_6::encode_to_vec(u);
+    assert_eq!(enc, dst);
+
     let mut dst = String::new();
     iso8859_6::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = iso8859_6::decode_to_string(c);
+    assert_eq!(dec, dst);
 }
 
 
@@ -43,7 +55,13 @@ fn test_iso8859_11() {
     iso8859_11::encode(u, &mut dst);
     assert_eq!(dst.as_slice(), c);
 
+    let enc = iso8859_11::encode_to_vec(u);
+    assert_eq!(enc, dst);
+
     let mut dst = String::new();
     iso8859_11::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = iso8859_11::decode_to_string(c);
+    assert_eq!(dec, dst);
 }

--- a/tests/utf8.rs
+++ b/tests/utf8.rs
@@ -6,13 +6,19 @@ fn test_utf8() {
     let u = "тест";
     let c: &[u8] = &[0xd1, 0x82, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82];
 
-    let mut dst = String::new();
-    utf8::decode(c, &mut dst);
-    assert_eq!(u, dst.as_str());
+    let mut dst = Vec::new();
+    utf8::encode(u, &mut dst);
+    assert_eq!(c, dst.as_slice());
+
+    let enc = utf8::encode_to_vec(u);
+    assert_eq!(enc, dst);
 
     let mut dst = String::new();
     utf8::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = utf8::decode_to_string(c);
+    assert_eq!(dec, dst);
 
     let bound = utf8::bound(c, 5);
     assert_eq!(bound, 4);
@@ -49,13 +55,19 @@ fn test_utf8_n_bytes() {
         0x78]
     ;
 
-    let mut dst = String::new();
-    utf8::decode(c, &mut dst);
-    assert_eq!(u, dst.as_str());
+    let mut dst = Vec::new();
+    utf8::encode(u, &mut dst);
+    assert_eq!(c, dst.as_slice());
+
+    let enc = utf8::encode_to_vec(u);
+    assert_eq!(enc, dst);
 
     let mut dst = String::new();
     utf8::decode(c, &mut dst);
     assert_eq!(u, dst.as_str());
+
+    let dec = utf8::decode_to_string(c);
+    assert_eq!(dec, dst);
 
     let bound = utf8::bound(c, 5);
     assert_eq!(bound, 4);


### PR DESCRIPTION
I have a use case for encode/decode functions that return owned data, this commit implements the required additions.

---
added encoding/decoding to owned data
added according test cases
changed one redundant decode test case each in UTF8 tests to become an encode test
fixed a few lints