### PR TITLE
Fix underflow when decoding undefined iso6937 symbols in range 0x7F-0x9F

### DIFF
--- a/src/iso6937.rs
+++ b/src/iso6937.rs
@@ -79,8 +79,11 @@ pub fn decode(src: &[u8], dst: &mut String) {
             }
 
             skip += 1;
-        } else {
+        } else if c >= 0xA0 {
             m = get_map(usize::from(c) - 0xA0);
+            skip += 1;
+        } else {
+            m = '�';
             skip += 1;
         }
 


### PR DESCRIPTION
Decoding the following with ISO 6937 causes an integer underflow with symbols in range 0x7F-0x9F:
`[86, 48, 49, 53, 54, 4F, 52, 59, 20, 87, 43, 68, 61, 6E, 6E, 65, 6C, 20, 86, 48, 44, 87]`
With my fix decodes to: `�HISTORY �Channel �HD� `

Note, I'm picking the decoding based on the first byte (0x86). According to the DVB specification, Annex A:  

*if the first byte of the text field has a value in the range "0x20" to "0xFF" then this and all subsequent bytes in the
text item are coded using the default character coding table (table 00 - Latin alphabet) of figure A.1;*

Table 00 points to ISO 6937. But since with ISO8859_1 it decodes just fine ( `HISTORY Channel HD`), this might be that the advertised encoding is wrong, so your decoding may be correct otherwise. 